### PR TITLE
Emit throttled record once per warning interval with breach message

### DIFF
--- a/fluent-plugin-quota-throttle.gemspec
+++ b/fluent-plugin-quota-throttle.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-quota-throttle"
-  spec.version       = "1.0.1"
+  spec.version       = "1.0.2"
   spec.authors       = ["Athish Pranav D", "Dipendra Singh", "Himanshu Soni", "Rubrik Inc."]
   spec.email         = ["athish.pranav@rubrik.com", "Dipendra.Singh@rubrik.com", "himanshu.soni@rubrik.com"]
   spec.summary       = %q{Fluentd filter for throttling logs based on a configurable quotas.}

--- a/lib/fluent/plugin/filter_quota_throttle.rb
+++ b/lib/fluent/plugin/filter_quota_throttle.rb
@@ -16,6 +16,8 @@ module Fluent::Plugin
     include Fluent::Plugin::Prometheus
     attr_reader :registry
 
+    THROTTLE_MESSAGE = "Throttling applied due to quota breach"
+
     desc "Path for the quota config file"
     config_param :path, :string, :default => nil
 
@@ -102,8 +104,17 @@ module Fluent::Plugin
         @metrics[:quota_exceeded].increment(by: 1, labels: labels.merge({quota: quota.name}))
       end
       
-      quota_breached(tag, time, record, bucket, quota)
-      nil
+      should_emit_once = quota_breached(tag, time, record, bucket, quota)
+      if should_emit_once
+        if record.key?("msg")
+          record["msg"] = THROTTLE_MESSAGE
+        elsif record.key?("log")
+          record["log"] = THROTTLE_MESSAGE
+        end
+        return record
+      end
+      
+      return nil
 
     end
 
@@ -115,18 +126,24 @@ module Fluent::Plugin
     #   +quota+: (Quota) The quota that has been breached
     #   +timestamp+: (Time) The timestamp of the record
     def quota_breached(tag, timestamp, record, bucket, quota)
+      should_emit_once = false
       if bucket.last_warning.nil? || Time.now - bucket.last_warning > @warning_delay
         log.warn "Quota breached for {group: #{bucket.group}, quota: #{quota.name}, total_logs: #{bucket.bucket_count_total}, limit: #{bucket.bucket_limit}, current_rate: #{bucket.approx_rate_per_second}}"
         bucket.last_warning = Time.now
+        should_emit_once = true
       end
       case quota.action
       when "drop"
         log.debug "Dropping record"
       when "reemit"
-        log.debug "Reemitting record"
-        new_tag = "#{@reemit_tag_prefix}.#{tag}"
-        router.emit(new_tag, timestamp, record)
+        unless should_emit_once
+          log.debug "Reemitting record"
+          new_tag = "#{@reemit_tag_prefix}.#{tag}"
+          router.emit(new_tag, timestamp, record)
+        end
       end
+
+      return should_emit_once
     end
 
     def get_labels(record)


### PR DESCRIPTION
## Summary
- On quota breach, sets `record["msg"]` to `Throttling applied due to quota breach`
- Returns the updated record through the filter once per `warning_delay` interval (instead of always dropping with `nil`)
- Skips the `reemit` action when `should_emit_once` is true to avoid emitting the record twice
- Bumps version to `1.0.2`

## Test plan
- [ ] Verify throttled records pass through with correct `msg`/`log` field on warning tick
- [ ] Verify records are dropped (nil) between warning ticks
- [ ] Verify `reemit` action does not double-emit when `should_emit_once` is true
- [ ] Verify `drop` action behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)